### PR TITLE
prevent func from being added to staged functions until confirmation

### DIFF
--- a/ui/src/components/Staged_functions.vue
+++ b/ui/src/components/Staged_functions.vue
@@ -35,11 +35,17 @@ export default {
   mounted () {
   },
   computed: {
+    confirmDeactiveFunction () {
+      return this.$store.getters.getConfirmDeactiveFunction
+    },
     levelControl () {
       return this.$store.getters.getLevelControl
     },
     stagedFunctions () {
       return this.levelControl.functions.stagedFunctions
+        .filter(func => {
+          return func.created_id !== this.confirmDeactiveFunction.created_id
+        })
     },
     permanentImages () {
       return this.$store.getters.getPermanentImages

--- a/ui/src/components/Staged_functions.vue
+++ b/ui/src/components/Staged_functions.vue
@@ -76,12 +76,16 @@ export default {
     confirmDeactivateFunction (evt) {
       const {oldIndex, newIndex} = evt
       const func = this.levelControl.functions.activeFuncs[oldIndex]
-      func.category = 'staged'
-      func.index = newIndex
-      // func.func = []
+
+      // if user drags command function ignore
+      if (!func) return
+
+      Object.assign(func, {
+        category: 'staged',
+        index: newIndex
+      })
       this.$store.dispatch('confirmDeactivateFunction', func)
       this.$root.$emit('bv::show::modal', 'confirm-deactivate-func')
-      // this.levelControl.deactivateFunction(func)
     }
   },
   components: {

--- a/ui/src/services/LevelControl.js
+++ b/ui/src/services/LevelControl.js
@@ -84,7 +84,6 @@ class LevelControl extends Ws {
   }
 
   deactivateFunction (func) {
-
     // clear function fields
     Object.assign(func, {
       func: []

--- a/ui/src/services/LevelControl.js
+++ b/ui/src/services/LevelControl.js
@@ -84,6 +84,12 @@ class LevelControl extends Ws {
   }
 
   deactivateFunction (func) {
+
+    // clear function fields
+    Object.assign(func, {
+      name: '',
+      func: []
+    })
     this._wsOnMessage((updated) => {
       this._setFunctions(updated.preparedFunctions)
     })

--- a/ui/src/services/LevelControl.js
+++ b/ui/src/services/LevelControl.js
@@ -87,7 +87,6 @@ class LevelControl extends Ws {
 
     // clear function fields
     Object.assign(func, {
-      name: '',
       func: []
     })
     this._wsOnMessage((updated) => {


### PR DESCRIPTION

### issues:

1. When I deactivate a function and decide not to go through with it the function still remains in staged functions. It may be a good idea to prevent the function from being added to staged functions in the ui until the server responds which will then update the list.

1. deactivated function name and funcs fields not cleared when deactivated
 1. error when dragging command function into staged

### changes:

1. filter active function in Staged_functions component
1. remove name and funcs when deactivating func
1. ignore command func in confirmDeactivateFunction