### PR TITLE
Implementation of feature "MBL: Change function syntax #589"

### DIFF
--- a/app/compiler/Compiler.scala
+++ b/app/compiler/Compiler.scala
@@ -207,7 +207,8 @@ object Compiler {
     element match {
       case MblList(Nil) =>
         Left((NoOperation, Map.empty[String, UserFunctionNamed], Map.empty[Int, UserFunctionLambda]))
-      case MblList(MblSymbol("defun") :: MblSymbol(name) :: elements) =>
+
+      case MblList(MblSymbol(name) :: MblSymbol("=>") :: elements) =>
         (errReduce orElse (opsReduce andThen { c =>
           val n = UserFunctionNamed(c._1, name)
           Left((NoOperation, c._2 + (name -> n), c._3))


### PR DESCRIPTION
Defun syntax replaced with error as in "(foo => (forward forward))"

if is still the same as it was syntactically conflictory to do "(foo => if 'any)"

Meanwhile, you can still get a "conditional function" that works the same
as the glyphs with "(foo => (if 'empty forward forward))"