### PR TITLE
Partial implementation of "Need a "scrub through" feature #438"

### DIFF
--- a/app/compiler/Compiler.scala
+++ b/app/compiler/Compiler.scala
@@ -156,7 +156,7 @@ object Compiler {
                 SetItemDown
               case id if allFunctions.contains(id) =>
                 f.color match {
-                  case "white" =>
+                  case Colors.white.name =>
                     UserFunctionRefById(id)
                   case _ =>
                     IfColor(Colors.from(f.color).getOrElse(Colors.anyColor), UserFunctionRefById(id))

--- a/app/compiler/operations/Initial.scala
+++ b/app/compiler/operations/Initial.scala
@@ -1,0 +1,3 @@
+package compiler.operations
+
+case object Initial extends Operation

--- a/app/compiler/processor/Processor.scala
+++ b/app/compiler/processor/Processor.scala
@@ -18,7 +18,7 @@ class Processor(val initialGridAndProgram: GridAndProgram, config: CompilerConfi
     val trace = initialGridAndProgram.program match {
       case uf: UserFunction => TraceTag(uf, 0)
     }
-    execute(state, Some((initialGridAndProgram.program, trace)), Seq.empty[(Operation, TraceTag)], 0)
+    execute(state, Some((Initial, TraceTag(UserFunction(), -1))), Seq((initialGridAndProgram.program, trace)), 0)
   }
 
   @tailrec
@@ -107,6 +107,9 @@ class Processor(val initialGridAndProgram: GridAndProgram, config: CompilerConfi
             state.currentRegister = state.currentRegister.copy(animation = Some(AnimationType.Bumped))
             Frame(operation._1, state.currentRegister, state.currentGrid, operation._2, Some(state.currentGrid.getRobotLocation))
         }
+
+      case Initial =>
+        Frame(operation._1, state.currentRegister, state.currentGrid, operation._2, Some(state.currentGrid.getRobotLocation))
 
       case _ => Frame(operation._1, state.currentRegister, state.currentGrid, operation._2)
     }


### PR DESCRIPTION
Puts a "Initial" frame that just references the robot at its starting point so a reverse scrub can return the robot to its starting position.