### PR TITLE
disables play button if failure, slider still works

### DIFF
--- a/ui/src/components/Grid_controls.vue
+++ b/ui/src/components/Grid_controls.vue
@@ -16,9 +16,10 @@
     >
     <img
       v-else
-      class="play dialog-button"
+      class="actual-play play dialog-button"
+      :class="levelControl.runCompiled.failure ? 'disabled' : ''"
       :src="permanentImages.buttons.playButton"
-      @click="levelControl.robot.state !== 'failure' ? levelControl.runCompiled.start() : ''"
+      @click="!levelControl.runCompiled.failure ? levelControl.runCompiled.start() : ''"
     />
     <img
       class="reset dialog-button"

--- a/ui/src/services/RunCompiled.js
+++ b/ui/src/services/RunCompiled.js
@@ -35,6 +35,7 @@ class RunCompiled extends GridAnimator {
   }
 
   lastFrame = null
+  failure = false
 
   _testForEmptyFunctions () {
     const mainFunction = $store.state.levelControl.functions.main.func
@@ -254,6 +255,7 @@ class RunCompiled extends GridAnimator {
   _failure (frame) {
     return this.initializeAnimation(frame, async () => {
       this.lastFrame = frame
+      this.failure = true
       this.robot.setState('paused')
       this._failedMessage()
       this._updateGalaxyData()


### PR DESCRIPTION
This is so that users don't try to press play when the robot is in a failed state.