### PR TITLE
add unmigrated social users to total user count

### DIFF
--- a/app/daos/Auth0LegacyDao.scala
+++ b/app/daos/Auth0LegacyDao.scala
@@ -7,13 +7,14 @@ import org.bson.codecs.Codec
 import org.bson.codecs.configuration.CodecRegistries.{fromProviders, fromRegistries}
 import org.bson.codecs.configuration.{CodecProvider, CodecRegistries}
 import org.mongodb.scala.bson.BsonDocument
-import org.mongodb.scala.bson.codecs.DEFAULT_CODEC_REGISTRY
+import org.mongodb.scala.bson.codecs.{DEFAULT_CODEC_REGISTRY, Macros}
 import org.mongodb.scala.model.Filters._
 import org.mongodb.scala.model.Indexes._
 import org.mongodb.scala.model.Updates._
 import org.mongodb.scala.{MongoDatabase, _}
 
 import scala.concurrent.{ExecutionContext, Future}
+import scala.util.{Failure, Success}
 
 class Auth0LegacyDao @Inject()(val db: MongoDatabase,
                                aLogger: SemanticLog,
@@ -23,9 +24,16 @@ class Auth0LegacyDao @Inject()(val db: MongoDatabase,
   private val collectionLabel = 'auth0legacy
   private val emailColumnLabel = 'email
   private val migratedColumnLabel = 'migrated
+  private val userIdColumnLabel = 'user_id
+
+  case class UnmigratedSocialUsers(count: Long)
 
   private val codecRegistry = fromRegistries(
-    fromProviders(aProviders: _*),
+    fromProviders(
+      Seq(
+        Macros.createCodecProvider[UnmigratedSocialUsers]()
+      ) ++ aProviders: _*
+    ),
     CodecRegistries.fromCodecs(aCodecs: _*),
     DEFAULT_CODEC_REGISTRY
   )
@@ -33,6 +41,9 @@ class Auth0LegacyDao @Inject()(val db: MongoDatabase,
   val collection: MongoCollection[Auth0LegacyUser] =
     db.getCollection[Auth0LegacyUser](collectionLabel.name).withCodecRegistry(codecRegistry)
 
+  val unmigratedColl: MongoCollection[UnmigratedSocialUsers] =
+    db.getCollection[UnmigratedSocialUsers](collectionLabel.name)
+      .withCodecRegistry(codecRegistry)
   def find(email: String): Future[Option[Auth0LegacyUser]] =
     collection.find(equal(emailColumnLabel.name, email)).toFuture().map(_.headOption)
 
@@ -41,11 +52,59 @@ class Auth0LegacyDao @Inject()(val db: MongoDatabase,
       .findOneAndUpdate(equal(emailColumnLabel.name, email), set(migratedColumnLabel.name, true))
       .toFutureOption()
 
-  private final val statement = BsonDocument(s"{${migratedColumnLabel.name}: false}")
-  def countUnmigrated: Future[Long] = {
+  private final val unmigratedUsersStatement = BsonDocument(s"{${migratedColumnLabel.name}: false}")
 
-    collection.count(statement).toFuture
+  private def countUnmigratedLocal: Future[Long] = {
+
+    collection.count(unmigratedUsersStatement).toFuture
   }
 
-  collection.createIndex(ascending(emailColumnLabel.name)).toFuture()
+  def countUnmigrated: Future[Long] = {
+
+    for {
+      local <- this.countUnmigratedLocal
+      social <- this.countUnmigratedSocial
+    } yield local + social
+  }
+
+  private final val matchSocialUsersStatement = BsonDocument(
+    """{$match: { user_id: {$not:/^mathbot\|.*|^auth0\|.*/ } }}"""
+  )
+
+  private def countUnmigratedSocial: Future[Long] = {
+
+    unmigratedColl
+      .aggregate(
+        Seq(
+          matchSocialUsersStatement,
+          BsonDocument(s"""
+                       |{ $$lookup: {
+                       |          from: "playeraccount",
+                       |          localField: "${userIdColumnLabel.name}",
+                       |          foreignField: "tokenId",
+                       |          as: "user",
+                       |        }
+                       |}
+                     """.stripMargin),
+          BsonDocument("""{ $match : { user: {$eq: []} }},"""),
+          BsonDocument("""{ $count: 'count'}""")
+        )
+      )
+      .toFuture()
+      .map(result => if (result.isEmpty) 0 else result.head.count)
+
+  }
+
+  collection.createIndex(ascending(emailColumnLabel.name)).toFuture().onComplete {
+    case Success(_) =>
+      aLogger.debug(SemanticLog.tags.index(collectionLabel.name, emailColumnLabel.name, "Created index"))
+    case Failure(t) =>
+      aLogger.error(SemanticLog.tags.index(collectionLabel.name, emailColumnLabel.name, t, "Failed to create index"))
+  }
+//  collection.createIndex(text(userIdColumnLabel.name)).toFuture().onComplete {
+//    case Success(_) =>
+//      aLogger.debug(SemanticLog.tags.index(collectionLabel.name, userIdColumnLabel.name, "Created index"))
+//    case Failure(t) =>
+//      aLogger.error(SemanticLog.tags.index(collectionLabel.name, userIdColumnLabel.name, t, "Failed to create index"))
+//  }
 }


### PR DESCRIPTION
fixes #743

issue:

documents in collection w/o migrated = true are not included
in total user count

changes:

for social users (non mathbot| or auth0| user_id)
lookup from playeraccounts, and include in total if no match